### PR TITLE
[Bug] CmdBurnUsq() have 1 arg, but should 2

### DIFF
--- a/x/stable/client/cli/tx.go
+++ b/x/stable/client/cli/tx.go
@@ -70,7 +70,7 @@ func CmdBurnUsq() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "burn [amount] [denom]",
 		Short: "Broadcast message burn",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {


### PR DESCRIPTION
## Brief
In `x/stable` CmdBurnUsq() have 1 arg, but should 2

## It will be done:
- [x] Fix bug

## Result:
- [x] Module works correctly according to the specification