### PR TITLE
[Fix] `x/stable` query pair error

### DIFF
--- a/x/stable/keeper/query.go
+++ b/x/stable/keeper/query.go
@@ -45,14 +45,14 @@ func (k Keeper) PairByPairId(goCtx context.Context, req *types.PairByPairIdReque
 		return nil, err
 	}
 
-	mintingFee, err := gmd.CalculateMintingFee(backing_ratio)
-	if err != nil {
-		return nil, err
+	mintingFee, _ := gmd.CalculateMintingFee(backing_ratio)
+	if mintingFee.IsNil() {
+		mintingFee = sdk.NewInt(9999)
 	}
 
-	burning_fee, err := gmd.CalculateBurningFee(backing_ratio)
-	if err != nil {
-		return nil, err
+	burningFee, _ := gmd.CalculateBurningFee(backing_ratio)
+	if burningFee.IsNil() {
+		burningFee = sdk.NewInt(9999)
 	}
 
 	return &types.PairRequestResponse{
@@ -65,7 +65,7 @@ func (k Keeper) PairByPairId(goCtx context.Context, req *types.PairByPairIdReque
 		MinAmountOut:      pair.MinAmountOut,
 		BackingRatio:      backing_ratio.Uint64(),
 		MintingFee:        mintingFee.Uint64(),
-		BurningFee:        burning_fee.Uint64(),
+		BurningFee:        burningFee.Uint64(),
 	}, nil
 }
 
@@ -92,12 +92,12 @@ func (k Keeper) PairById(goCtx context.Context, req *types.PairByIdRequest) (*ty
 
 	mintingFee, _ := gmd.CalculateMintingFee(backing_ratio)
 	if mintingFee.IsNil() {
-		mintingFee = sdk.NewInt(0)
+		mintingFee = sdk.NewInt(9999)
 	}
 
 	burningFee, _ := gmd.CalculateBurningFee(backing_ratio)
 	if burningFee.IsNil() {
-		burningFee = sdk.NewInt(0)
+		burningFee = sdk.NewInt(9999)
 	}
 
 	return &types.PairRequestResponse{
@@ -136,9 +136,9 @@ func (k Keeper) GetAmountOutByAmountIn(goCtx context.Context, req *types.GetAmou
 	}
 	switch req.Action {
 	case "mint":
-		mintingFee, _ := gmd.CalculateMintingFee(backing_ratio)
-		if mintingFee.IsNil() {
-			mintingFee = sdk.NewInt(0)
+		mintingFee, err := gmd.CalculateMintingFee(backing_ratio)
+		if err != nil {
+			return nil, err
 		}
 		amountOutToMint := k.CalculateAmountToMint(sdk.NewIntFromUint64(req.AmountIn), atomPrice, mintingFee)
 		return &types.GetAmountOutByAmountInResponse{
@@ -147,9 +147,9 @@ func (k Keeper) GetAmountOutByAmountIn(goCtx context.Context, req *types.GetAmou
 			Action:    req.Action,
 		}, nil
 	case "burn":
-		burningFee, _ := gmd.CalculateBurningFee(backing_ratio)
-		if burningFee.IsNil() {
-			burningFee = sdk.NewInt(0)
+		burningFee, err := gmd.CalculateBurningFee(backing_ratio)
+		if err != nil {
+			return nil, err
 		}
 		amountOutToSend := k.CalculateAmountToSend(sdk.NewIntFromUint64(req.AmountIn), atomPrice, burningFee)
 		return &types.GetAmountOutByAmountInResponse{


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
Closes: #XXX

## Brief
When BR <85% or >140% the request for pairing data returns an error rather than pair information

## It will be done:
- [x] Fixing an error when requesting a pair

## Result:
- [x] Module works correctly according to the specification
