### PR TITLE
[Bug] Fix zero QM in `x/stable`

### DIFF
--- a/x/stable/keeper/utils.go
+++ b/x/stable/keeper/utils.go
@@ -7,6 +7,10 @@ import (
 )
 
 func CalculateBackingRatio(qm sdk.Int, ar sdk.Int, atomPrice sdk.Int) (sdk.Int, error) {
+	if qm.IsZero() && !ar.IsZero() {
+		qm = types.SdkMultiplier
+	}
+
 	if qm.IsZero() && ar.IsZero() {
 		backing_ratio = sdk.NewInt(100)
 	} else {

--- a/x/stable/types/multipliers.go
+++ b/x/stable/types/multipliers.go
@@ -6,6 +6,7 @@ import (
 
 var (
 	Multiplier        sdk.Int = sdk.NewInt(int64(10000))
+	SdkMultiplier     sdk.Int = sdk.NewInt(int64(1000000))
 	FeeMultiplier     sdk.Int = sdk.NewInt(int64(100000))
 	MintUsqMultiplier sdk.Int = sdk.NewInt(int64(1000))
 	BurnUsqMultiplier sdk.Int = sdk.NewInt(int64(1000000000))


### PR DESCRIPTION
* add new multiplier

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
Closes: #XXX

## Brief
If all USQs are burned, the QM parameter becomes 0 and this causes an error in the BR calculation: "You cannot divide by 0"

## It will be done:
- [x] Fixing zero QM problem
- [x] Add tests to verify GMB operations

## Result:
- [x] Module works correctly according to the specification
