### PR TITLE
[Feature] Add ChangeReserveFundAddress Proposal in `x/stable`

### DIFF
--- a/x/stable/proposal_handler.go
+++ b/x/stable/proposal_handler.go
@@ -16,6 +16,8 @@ func NewStableProposalHandler(k *keeper.Keeper) govtypes.Handler {
 			return handleRegisterPairProposal(ctx, k, c)
 		case *types.RegisterChangeBurningFundAddressProposal:
 			return handleRegisterChangeBurningFundAddressProposal(ctx, k, c)
+		case *types.RegisterChangeReserveFundAddressProposal:
+			return handleRegisterChangeReserveFundAddressProposal(ctx, k, c)
 		default:
 			return sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized %s proposal content type: %T", types.ModuleName, c)
 		}
@@ -52,6 +54,23 @@ func handleRegisterChangeBurningFundAddressProposal(ctx sdk.Context, k *keeper.K
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			types.EventRegisterChangeBurningFundAddressProposal,
+		),
+	)
+	return nil
+}
+
+func handleRegisterChangeReserveFundAddressProposal(ctx sdk.Context, k *keeper.Keeper, p *types.RegisterChangeReserveFundAddressProposal) error {
+	address, err := sdk.AccAddressFromBech32(p.Address)
+	if err != nil {
+		return err
+	}
+	err = k.ChangeReserveFundAddress(ctx, address)
+	if err != nil {
+		return err
+	}
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.EventRegisterChangeReserveFundAddressProposal,
 		),
 	)
 	return nil

--- a/x/stable/types/event.go
+++ b/x/stable/types/event.go
@@ -2,7 +2,8 @@ package types
 
 const (
 	EventRegisterCreateNewPairProposal            = "register_create_new_pair_proposal"
-	EventRegisterChangeBurningFundAddressProposal = "register_change_stability_fund_address_proposal"
+	EventRegisterChangeBurningFundAddressProposal = "register_change_burning_fund_address_proposal"
+	EventRegisterChangeReserveFundAddressProposal = "register_change_reserve_fund_address_proposal"
 	AttributeValueCategory                        = ModuleName
 	AttributeKeyActionMint                        = "mint"
 	AttributeKeyActionBurn                        = "burn"


### PR DESCRIPTION
Closes: #XXX

## Brief
in previous versions of Qube in module `x/stable` there was no possibility to change Reserve Fund by sending transaction from command line, and also there was no handler of this offer. This PR introduces these functions.

## It will be done:
- [x] Add RegisterChangeReserveFundAddressProposal in `x/stable` cli

## Result:
- [x] Module works correctly according to the specification
