### PR TITLE
[Bug] Adding `x/grow` module status check to EndBlocker in `x/grow`

### DIFF
--- a/x/grow/abci.go
+++ b/x/grow/abci.go
@@ -14,6 +14,12 @@ import (
 /* #nosec */
 func EndBlocker(ctx sdk.Context, k keeper.Keeper) error {
 	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyEndBlocker)
+
+	err := k.CheckGrowStatus(ctx)
+	if err != nil {
+		return types.ErrGrowNotActivated
+	}
+
 	allGTokenPair := k.GetAllPair(ctx)
 	for _, gp := range allGTokenPair {
 		action, rawValue, err := k.CheckYieldRate(ctx, gp)


### PR DESCRIPTION
Closes: #XXX

## Brief
GTokenPair will be added during the `x/grow` launch preparation. In earlier versions, when new pairs were added, the price of the gToken would start to increase even though the `x/grow` was not active. This PR fixes this bug.

## It will be done:
- [x] Added CheckGrowStatus to EndBlocker in `x/grow`

## Result:
- [x] Module works correctly according to the specification
