### PR TITLE
[Fix] LastTimeUpdateReserve not updating in `x/grow`

### DIFF
--- a/x/grow/keeper/yield.go
+++ b/x/grow/keeper/yield.go
@@ -166,5 +166,11 @@ func (k Keeper) CalculateAddToReserveValue(ctx sdk.Context, val sdk.Int, gTokenP
 	if (sdk.NewInt(31536000).Quo(diff)).IsNil() || (sdk.NewInt(31536000).Quo(diff)).IsZero() {
 		return sdk.Int{}, true
 	}
+	/*
+		TODO
+		Before you enable the x/grow for the first time, need to use upgrades to change the LastTimeUpdateReserve
+	*/
+	k.SetLastTimeUpdateReserve(ctx, sdk.NewInt(ctx.BlockTime().Unix()))
+
 	return val.Quo(sdk.NewInt(31536000).Quo(diff)), false
 }

--- a/x/grow/keeper/yield.go
+++ b/x/grow/keeper/yield.go
@@ -170,7 +170,10 @@ func (k Keeper) CalculateAddToReserveValue(ctx sdk.Context, val sdk.Int, gTokenP
 		TODO
 		Before you enable the x/grow for the first time, need to use upgrades to change the LastTimeUpdateReserve
 	*/
-	k.SetLastTimeUpdateReserve(ctx, sdk.NewInt(ctx.BlockTime().Unix()))
+	err := k.SetLastTimeUpdateReserve(ctx, sdk.NewInt(ctx.BlockTime().Unix()))
+	if err != nil {
+		return sdk.Int{}, true
+	}
 
 	return val.Quo(sdk.NewInt(31536000).Quo(diff)), false
 }


### PR DESCRIPTION
Closes: #XXX

## Brief
In the Grow module, the time of change of reserves has not changed

## It will be done:
- [x] LastTimeUpdateReserve is update every 10 sec
- [x] Testing

## Result:
- [x] Module works correctly according to the specification
