### PR TITLE
[Fix] Adding `SetParams` function in `grow/abci`

### DIFF
--- a/x/grow/abci.go
+++ b/x/grow/abci.go
@@ -182,6 +182,7 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) error {
 	}
 
 	params.LastTimeUpdateReserve = uint64(ctx.BlockTime().Unix())
+	k.SetParams(ctx, params)
 
 	return nil
 }


### PR DESCRIPTION
Closes: #XXX

## Brief
In `grow/abci`, we assign new values to some fields in params, but the new params are not saved. This PR fixes that

## It will be done:
- [x] Adding `SetParams` function in `grow/abci`
- [x] Testing changes 

## Result:
- [x] Module works correctly according to the specification
